### PR TITLE
hotfix: implement SSR on non-client heavy components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Hero } from '@/components/Hero/hero';
 import { AboutMe } from '@/components/About_Me/about-me';
 import { Projects } from '@/components/Projects/projects';

--- a/src/components/About_Me/about-me.tsx
+++ b/src/components/About_Me/about-me.tsx
@@ -28,7 +28,7 @@ export function AboutMe() {
 
         {/* ABOUT ME */}
         <AboutMeBento />
-        
+
         {/* TECH STACK */}
         <TechStackBento />
 

--- a/src/components/About_Me/bentos/AboutMeBento.tsx
+++ b/src/components/About_Me/bentos/AboutMeBento.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import Link from 'next/link';
 import {
   Card,
@@ -11,12 +10,6 @@ import { ChevronDown, ChevronUp } from 'lucide-react';
 import { ShineBorder } from '@/components/magicui/shine-border';
 
 export function AboutMeBento() {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  const toggleExpanded = () => {
-    setIsExpanded(!isExpanded);
-  };
-
   const fullText = (
     <>
       I&apos;ve always been passionate about tech, art and design, and UI/UX to
@@ -58,6 +51,7 @@ export function AboutMeBento() {
 
   const shortText =
     "I've always been passionate about tech, art and design, and UI/UX to improve the quality of life.";
+
   return (
     <Card className='relative col-span-1 md:col-span-8 bg-gradient-to-b from-transparent to-slate-700/70 hover:to-slate-600/70 border border-slate-500 hover:border-slate-300 py-6 gap-1 text-white transition-colors duration-300'>
       <ShineBorder shineColor={['#34d399', '#66a4ea', '#FFFFFF']} />
@@ -66,23 +60,10 @@ export function AboutMeBento() {
       </CardHeader>
       <CardContent className='flex flex-col items-center h-full px-6'>
         <CardDescription className='lg:text-base text-slate-200'>
-          {/* Show short text on mobile, full text on larger screens or when expanded */}
-          <span className='md:hidden'>{isExpanded ? fullText : shortText}</span>
-          <span className='hidden md:block'>{fullText}</span>
-        </CardDescription>
+          {/* Show short text on mobile, full text on larger screens */}
 
-        {/* View More button (mobile) */}
-        <button
-          onClick={toggleExpanded}
-          className='md:hidden mt-4 flex items-center gap-2 text-sky-600 hover:text-sky-500 transition-colors duration-200 text-sm hover:cursor-pointer'
-        >
-          <span>{isExpanded ? 'View Less' : 'View More'}</span>
-          {isExpanded ? (
-            <ChevronUp className='w-4 h-4' />
-          ) : (
-            <ChevronDown className='w-4 h-4' />
-          )}
-        </button>
+          <span className=''>{fullText}</span>
+        </CardDescription>
       </CardContent>
     </Card>
   );

--- a/src/components/About_Me/bentos/GithubActivityBento.tsx
+++ b/src/components/About_Me/bentos/GithubActivityBento.tsx
@@ -1,9 +1,21 @@
+'use client';
+
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import Link from 'next/link';
-import GitHubCalendar from 'react-github-calendar';
+import dynamic from 'next/dynamic';
 // icons
 import { SiGithub } from 'react-icons/si';
 import { ShineBorder } from '@/components/magicui/shine-border';
+
+// GitHub calendar needs client-side rendering
+const GitHubCalendar = dynamic(() => import('react-github-calendar'), {
+  ssr: false,
+  loading: () => (
+    <div className='flex items-center justify-center h-32 text-slate-400'>
+      Loading GitHub activity...
+    </div>
+  ),
+});
 
 export function GithubActivityBento() {
   return (

--- a/src/components/About_Me/bentos/SpotifyLastPlayedBento.tsx
+++ b/src/components/About_Me/bentos/SpotifyLastPlayedBento.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useFormattedSpotifyTrack } from '@/hooks/useSpotifyLastPlayed';
 import Image from 'next/image';
 import Link from 'next/link';

--- a/src/components/Contact/contact.tsx
+++ b/src/components/Contact/contact.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import Image from 'next/image';
 import { motion } from 'motion/react';

--- a/src/components/ui/equalizer-canvas.tsx
+++ b/src/components/ui/equalizer-canvas.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useRef } from 'react';
 
 // Equalizer Canvas Component


### PR DESCRIPTION
hotfix: implement SSR on non-client heavy components
- removed 'use client' directive from page.tsx and about-me.tsx
- removed react hooks from AboutMeBento.tsx to allow SSR
- made Github and Spotify Bentos CSR (due to tanstack query)
- made contact.tsx CSR (due to tanstack query)
- made equalizer html canvas CSR (due to useRef)