### PR TITLE
hotfix: remove unnecessary log for github calendar scroll

### DIFF
--- a/src/components/About_Me/bentos/GithubActivityBento.tsx
+++ b/src/components/About_Me/bentos/GithubActivityBento.tsx
@@ -34,8 +34,6 @@ export function GithubActivityBento() {
         scrollContainer.scrollLeft =
           scrollContainer.scrollWidth - scrollContainer.clientWidth;
 
-        console.log('Scrolled GitHub calendar to latest contributions');
-
         // Reset scroll behavior after scrolling
         setTimeout(() => {
           scrollContainer.style.scrollBehavior = 'auto';


### PR DESCRIPTION
hotfix: remove unnecessary log for github calendar scroll from GithubActivityBento useEffect